### PR TITLE
Final constraint alternative

### DIFF
--- a/Code/battery_electric_vehicle.py
+++ b/Code/battery_electric_vehicle.py
@@ -5,14 +5,14 @@ wie groß die Batterie ist.
 """
 
 class BatteryElectricVehicle:
-    def __init__(self, home_bus, e_bat, bus_voltage, soc_start=50, soc_target=100, t_target=20, resolution=None):
+    def __init__(self, home_bus, e_bat, bus_voltage, soc_start=50, soc_target=100, t_target=17, resolution=60):
         self.home_bus = home_bus
         self.e_bat = e_bat
         self.bus_voltage = bus_voltage
         self.soc_start = soc_start
         self.soc_target = soc_target
-        self.t_target = t_target
         self.resolution = resolution
+        self.t_target = int(t_target * 60 / self.resolution)
         self.soc_list = [soc_start]
         self.is_loading = True
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Masterarbeit
-Der Python-Code und und das Latex für den Bericht sind hier gespeichert
+Der Python-Code ist hier gespeichert


### PR DESCRIPTION
Das "letzte" Constraint `ensure_final_soc` (welches die in den einzelnen Zeitpunkten geladenen Energiemengen aufaddiert) ist fertig. Aber man kann das auch weglassen - die Ergebnisse sind genau dieselben. Die Information steckt nämlich auch schon in dem Constraint `track_socs`. Außerdem laden die BEVs jetzt wirklich bis zu ihrer `t_target` auf ihren `soc_target`, weil jetzt mit lower bounds für `SOC` dafür geschaffen ist.